### PR TITLE
Implement a Substring block

### DIFF
--- a/TagScriptEngine/block/__init__.py
+++ b/TagScriptEngine/block/__init__.py
@@ -10,4 +10,5 @@ from .assign import AssignmentBlock
 from .strf import StrfBlock
 from .breakblock import BreakBlock
 from .control import AnyBlock, AllBlock, IfBlock
+from .substr import SubstringBlock
 

--- a/TagScriptEngine/block/substr.py
+++ b/TagScriptEngine/block/substr.py
@@ -9,17 +9,16 @@ class SubstringBlock(Block):
         return any([dec=="substr",dec=="substring"])
 
     def process(self, ctx : Interpreter.Context) -> Optional[str]:
-        print(ctx.verb.parameter)
         try:
             
             if "-" in ctx.verb.parameter:
                 spl = ctx.verb.parameter.split("-")
-                start = int(spl[0])
-                end = int(spl[1])
+                start = int(float(spl[0]))
+                end = int(float(spl[1]))
 
                 return ctx.verb.payload[start:end]
             else:
-                start = int(ctx.verb.parameter)
+                start = int(float(ctx.verb.parameter))
 
                 return ctx.verb.payload[start:]
         except:

--- a/TagScriptEngine/block/substr.py
+++ b/TagScriptEngine/block/substr.py
@@ -1,0 +1,27 @@
+from .. import Interpreter, adapter
+from ..interface import Block
+from typing import Optional
+import random, math
+
+class SubstringBlock(Block):
+    def will_accept(self, ctx : Interpreter.Context) -> bool:
+        dec = ctx.verb.declaration.lower()
+        return any([dec=="substr",dec=="substring"])
+
+    def process(self, ctx : Interpreter.Context) -> Optional[str]:
+        print(ctx.verb.parameter)
+        try:
+            
+            if "-" in ctx.verb.parameter:
+                spl = ctx.verb.parameter.split("-")
+                start = int(spl[0])
+                end = int(spl[1])
+
+                return ctx.verb.payload[start:end]
+            else:
+                start = int(ctx.verb.parameter)
+
+                return ctx.verb.payload[start:]
+        except:
+            return None
+

--- a/playground.py
+++ b/playground.py
@@ -12,7 +12,8 @@ blocks = [
     block.AssignmentBlock(),
     block.FiftyFiftyBlock(),
     block.ShortCutRedirectBlock("message"),
-    block.LooseVariableGetterBlock()
+    block.LooseVariableGetterBlock(),
+	block.SubstringBlock()
 ]
 x = Interpreter(blocks)
 


### PR DESCRIPTION
Not really familiar with Python, so if anything should be different than it is, feel free to point it out or change.

Implements a block allowing you to retrieve a subselection of a full string.

The syntax is as follows:

```
{substr(0-4):Hello there!}         = Hell
{substr(8):I am a Shell}           = hell
```

The numbers can either be a range, making it start at the character at the first index (inclusive), until the character at the last index (exclusive), or a single number, making it start at the character at the first index (inclusive) until the end of the string.

Some more detailed examples of usage: (don't really have any use, just to show what it's capable of)

```
Hello {substr({range:0-3}-{range:4-7}):Streammz}
{let(start):{math:{range:0-4}*2}} {substr({start}-{math:{start}+2}):thinking}
```